### PR TITLE
use ws when base starts with http://

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,11 @@ Cypress.on('window:load', (win) => {
     );
   }
 
-  const url = baseUrl.replace(/https?/, 'wss');
+  let url = baseUrl.replace(/https?/, 'wss');
+  if (baseUrl.startsWith("http://")) {
+    url = url.replace(/^wss/, "ws")
+  }
+
   const socket = new WebSocket(`${url}/sockjs-node`);
   let timeout;
 


### PR DESCRIPTION
https://github.com/Svish/cypress-hmr-restarter/issues/12

This change uses "ws" when base url starts from "http://", because otherwise CRA devserver started on http://localhost:3000 (default) does not work with this plugin (devserver uses ws://, not wss://). There's probably a way to make CRA work on https and devserver on wss, but that requires additional configurations and does not seem to be very beneficial even from security perspective. 