### PR TITLE
Small doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import 'cypress-hmr-restarter/gatsby';
 ```jsonc
 {
   // Overrides assuming URL via baseUrl
-  "hmrUrl": "ws://localhost:3000/socks-node", // default import
+  "hmrUrl": "ws://localhost:3000/sockjs-node", // default import
   "hmrUrl": "http://localhost:3000/__webpack_hmr", // gatsby import
 
   // Overrides delay between event and restart (ms)

--- a/README.md
+++ b/README.md
@@ -52,5 +52,6 @@ import 'cypress-hmr-restarter/gatsby';
 When using the [Cypress Test Runner](https://docs.cypress.io/guides/core-concepts/test-runner.html) (`cypress open`), after the window has loaded, it will try to connect and listen for events. When an event signifying a change has happened, it will first try clicking the stop button, and then, after a short delay, it will click the restart button.
 
 - The default import connects to the [`webpack-dev-server`](https://www.npmjs.com/package/webpack-dev-server) websocket at either `<hmrUrl>` or `ws://<baseUrl>/sockjs-node` (`wss:` if `https:`), and listens for messages with the type `invalid`.
+**IMPORTANT:** You need to ensure that [`transportMode`](https://webpack.js.org/configuration/dev-server/#devservertransportmode) option of `webpack-dev-server` is set to `ws` for the feature to work.
 
 - The gatsby import connects to the [`webpack-hot-middleware`](https://www.npmjs.com/package/webpack-hot-middleware) event source at either `<hmrUrl>` or `<baseUrl>/__webpack_hmr`, and listens for messages with the action `built`.


### PR DESCRIPTION
Hi, thanks for that plugin, really useful !

While setting up my dev environment, I noticed there was an important typo in the **Options** section of the documentation, that PR fixes it.

I also noticed that for default import, the `transportMode` option of `webpack-dev-server` must be explicitly set to `ws` or the connection to the websocket fails. I though it was important to mention it in the doc.