### PR TITLE
Fixed "Cypress stops after 3 tests in Storybook"

### DIFF
--- a/gatsby.js
+++ b/gatsby.js
@@ -37,6 +37,12 @@ Cypress.on('window:load', (win) => {
         break;
     }
   });
+  
+  win.onbeforeunload = () => {
+    // Ensure that the source is closed if the window is unloaded
+    console.debug(LOG_TAG, `Close the HMR Connection`);
+    source.close();
+  }
 });
 
 function getUrl() {


### PR DESCRIPTION
When running in Storybook, after 3 tests, Cypress will hang on "loading iframe.html".

By ensuring that the EventSource is closed during `onbeforeunload`, this fixes the issue.